### PR TITLE
Update better-wp-showhide-elements.js

### DIFF
--- a/better-wp-showhide-elements.js
+++ b/better-wp-showhide-elements.js
@@ -14,12 +14,29 @@ var wp_showhide = {
 		
 		if (wp_showhide.list[index].state == "visible") {
 			wp_showhide.list[index].state = "hidden";
-			theName.style.display = "none";
+			/* mult div addition */
+			var divs = document.getElementsByTagName("div");
+			for (var i = 0;i < divs.length;i++) {
+				if (divs[i].id.match(theName) != null) 
+				{
+      				divs[i].style.display = "none";       				
+   				}
+			}
+			/* END mult div addition */		
+			
 			element.innerHTML = wp_showhide.list[index].values[0];
 		}
 		else {
 			wp_showhide.list[index].state = "visible";
-			theName.style.display = "block";
+			/* mult div addition */
+			var divs = document.getElementsByTagName("div");
+			for (var i = 0;i < divs.length;i++) {
+				if (divs[i].id.match(theName) != null) 
+				{
+      				divs[i].style.display = "block";       				
+   				}
+			}
+			/* END mult div addition */		
 			element.innerHTML = wp_showhide.list[index].values[1];
 		}
 	},
@@ -46,13 +63,27 @@ var wp_showhide = {
 		
 		for (var i = 0; i < wp_showhide.list.length; i++) {
 			if (wp_showhide.list[i].state == "visible") {
-				var div = document.getElementById(wp_showhide.list[i].name);
-				div.style.display = "block";
+				/* mult div addition */
+				var divs = document.getElementsByTagName("div");
+				for (var n = 0;n < divs.length;n++) {
+				if (divs[n].id.match(wp_showhide.list[i].name) != null) 
+				{
+      				divs[n].style.display = "block";       				
+   				}
+				}
+				/* END mult div addition */
 				wp_showhide.list[i].dom.innerHTML = wp_showhide.list[i].values[1];
 			}
 			else {
-				var div = document.getElementById(wp_showhide.list[i].name);
-				div.style.display = "none";
+				/* mult div addition */
+				var divs = document.getElementsByTagName("div");
+				for (var p = 0;p < divs.length;p++) {
+				if (divs[p].id.match(wp_showhide.list[i].name) != null) 
+				{
+      				divs[p].style.display = "none";       				
+   				}
+				}
+				/* END mult div addition */
 				wp_showhide.list[i].dom.innerHTML = wp_showhide.list[i].values[0];
 			}
 		}


### PR DESCRIPTION
Hi Andrew, 

Here is a description of my changes:

I have just extended the "better-wordpress-showhide" plugin a bit. Now you can add a "show all elements" link and use it to show/hide a bunch of elements at once.

You can see it in use at http://www.lamphp.net/heather-propes/ ("show jobs" link).

You just need to create a link that refers to an element that would be the root of all the elements you want to show or hide, i.e. for elements

myJobId1
myJobId2
myJobId3

you would control them with this link:

<a class="togglelink" onclick="wp_showhide.main(this, 'myJobId')" href="javascript:void(0)">["show all", "hide all", "visible"]</a> 

You can still control the divs individually by refering to their exact names. HOWEVER if you are going to control a bunch of divs at once, then you shouldn't also try to control them individually, as the labels get confused.
